### PR TITLE
Fixed problem with wp_logout returning HTML

### DIFF
--- a/assets/js/wp-delete-user-accounts.js
+++ b/assets/js/wp-delete-user-accounts.js
@@ -20,24 +20,34 @@ jQuery(document).ready(function($) {
 
 		// Send the AJAX POST request
 		var send = function() {
-			$.post( ajaxurl, data, function(response) {
-				if ( typeof( response.status ) != 'undefined' && response.status == 'success' ) {
-					// Account deleted
-					swal(
-						{
-							title: response.title,
-							text: response.message,
-							type: 'success',
-							timer: 6000
-						},
-						function() {
-							window.location.href = wp_delete_user_accounts_js.redirect_url;
-						}
-					);
-				} else { // Error occurred
-					swal( response.title, response.message, 'error' );
+			$.ajax({
+				type: "POST",
+				url: ajaxurl,
+				data: data,
+				dataType: 'json',
+				success: function(response) {
+					if ( typeof( response.status ) != 'undefined' && response.status == 'success' ) {
+			 		// Account deleted
+			 		swal(
+			 			{
+			 				title: response.title,
+			 				text: response.message,
+			 				type: 'success',
+			 				timer: 6000
+			 			},
+			 			function() {
+			 				window.location.href = wp_delete_user_accounts_js.redirect_url;
+			 			}
+			 		);
+			 	  } else { // Error occurred
+			 		swal( response.title, response.message, 'error' );
+			 	  }
+				},
+				error: function(jqXHR, textStatus, errorThrown) {
+					swal( wp_delete_user_accounts_js.general_error_title, wp_delete_user_accounts_js.general_error_text, 'error' );
+					console.log(jqXHR, textStatus, errorThrown);
 				}
-			} );
+			  });
 
 			return false;
 		}

--- a/assets/js/wp-delete-user-accounts.js
+++ b/assets/js/wp-delete-user-accounts.js
@@ -27,27 +27,27 @@ jQuery(document).ready(function($) {
 				dataType: 'json',
 				success: function(response) {
 					if ( typeof( response.status ) != 'undefined' && response.status == 'success' ) {
-			 		// Account deleted
-			 		swal(
-			 			{
-			 				title: response.title,
-			 				text: response.message,
-			 				type: 'success',
-			 				timer: 6000
-			 			},
-			 			function() {
-			 				window.location.href = wp_delete_user_accounts_js.redirect_url;
-			 			}
-			 		);
-			 	  } else { // Error occurred
-			 		swal( response.title, response.message, 'error' );
-			 	  }
+						// Account deleted
+						swal(
+							{
+								title: response.title,
+								text: response.message,
+								type: 'success',
+								timer: 6000
+							},
+							function() {
+								window.location.href = wp_delete_user_accounts_js.redirect_url;
+							}
+						);
+					} else { // Error occurred
+						swal( response.title, response.message, 'error' );
+					}
 				},
 				error: function(jqXHR, textStatus, errorThrown) {
 					swal( wp_delete_user_accounts_js.general_error_title, wp_delete_user_accounts_js.general_error_text, 'error' );
 					console.log(jqXHR, textStatus, errorThrown);
 				}
-			  });
+			});
 
 			return false;
 		}

--- a/includes/process-ajax.php
+++ b/includes/process-ajax.php
@@ -50,9 +50,6 @@ class WP_Delete_User_Accounts_AJAX {
 		// Get the current user
 		$user_id = get_current_user_id();
 
-		// Destroy user's session
-		wp_logout();
-
 		// Delete the user's account
 		$deleted = wp_delete_user( $user_id );
 

--- a/languages/wp-delete-user-accounts.pot
+++ b/languages/wp-delete-user-accounts.pot
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 wp-delete-user-accounts
+# Copyright (C) 2019 wp-delete-user-accounts
 # This file is distributed under the same license as the wp-delete-user-accounts package.
 msgid ""
 msgstr ""
@@ -16,47 +16,55 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: wp-delete-user-accounts.php:141
-msgid "Whoa, there!"
-msgstr ""
-
-#: wp-delete-user-accounts.php:142
-msgid "Once you delete your account, there's no getting it back. Make sure you want to do this."
+#: wp-delete-user-accounts.php:140
+msgid "DELETE"
 msgstr ""
 
 #: wp-delete-user-accounts.php:143
-msgid "Yep, delete it"
+msgid "Whoa, there!"
 msgstr ""
 
 #: wp-delete-user-accounts.php:144
-msgid "Cancel"
-msgstr ""
-
-#: wp-delete-user-accounts.php:145
-msgid "Error"
+msgid "Once you delete your account, there's no getting it back. Make sure you want to do this."
 msgstr ""
 
 #: wp-delete-user-accounts.php:146
-msgid "Your confirmation input was incorrect."
+msgid "Yep, delete it"
 msgstr ""
 
 #: wp-delete-user-accounts.php:147
-msgid "Processing..."
+msgid "Cancel"
 msgstr ""
 
-#: wp-delete-user-accounts.php:148
-msgid "Just a moment while we process your request."
+#: wp-delete-user-accounts.php:148, wp-delete-user-accounts.php:150
+msgid "Error"
 msgstr ""
 
 #: wp-delete-user-accounts.php:149
-msgid "Confirm by typing DELETE"
+msgid "Your confirmation input was incorrect."
 msgstr ""
 
-#: includes/admin.php:30
+#: wp-delete-user-accounts.php:151
+msgid "Something went wrong."
+msgstr ""
+
+#: wp-delete-user-accounts.php:152
+msgid "Processing..."
+msgstr ""
+
+#: wp-delete-user-accounts.php:153
+msgid "Just a moment while we process your request."
+msgstr ""
+
+#: wp-delete-user-accounts.php:154
+msgid "Confirm by typing"
+msgstr ""
+
+#: includes/admin-profile.php:30
 msgid "Delete Account"
 msgstr ""
 
-#: includes/admin.php:32, includes/frontend.php:43
+#: includes/admin-profile.php:32, includes/frontend.php:43
 msgid "This will cause your account to be permanently deleted. You will not be able to recover your account."
 msgstr ""
 
@@ -64,7 +72,7 @@ msgstr ""
 msgid "Delete My Account"
 msgstr ""
 
-#: includes/process-ajax.php:36, includes/process-ajax.php:45, includes/process-ajax.php:80
+#: includes/process-ajax.php:36, includes/process-ajax.php:45, includes/process-ajax.php:69
 msgid "Error!"
 msgstr ""
 
@@ -76,14 +84,14 @@ msgstr ""
 msgid "Administrators cannot delete their own accounts."
 msgstr ""
 
-#: includes/process-ajax.php:72
+#: includes/process-ajax.php:61
 msgid "Success!"
 msgstr ""
 
-#: includes/process-ajax.php:73
+#: includes/process-ajax.php:62
 msgid "Your account was successfully deleted. Fair well."
 msgstr ""
 
-#: includes/process-ajax.php:81
+#: includes/process-ajax.php:70
 msgid "Request failed."
 msgstr ""

--- a/wp-delete-user-accounts.php
+++ b/wp-delete-user-accounts.php
@@ -137,7 +137,7 @@ class WP_Delete_User_Accounts {
 
 		global $post;
 
-		$confirm_text = apply_filters( 'wp_delete_user_account_confirm_delete_text', __( 'DELETE', 'tdomain' ) );
+		$confirm_text = apply_filters( 'wp_delete_user_account_confirm_delete_text', __( 'DELETE', 'wp-delete-user-accounts' ) );
 
 		$vars = apply_filters( 'wp_delete_user_accounts_localize_script_vars', array(
 			'alert_title' => __( 'Whoa, there!', 'wp-delete-user-accounts' ),

--- a/wp-delete-user-accounts.php
+++ b/wp-delete-user-accounts.php
@@ -147,6 +147,8 @@ class WP_Delete_User_Accounts {
 			'button_cancel_text' => __( 'Cancel', 'wp-delete-user-accounts' ),
 			'incorrect_prompt_title' => __( 'Error', 'wp-delete-user-accounts' ),
 			'incorrect_prompt_text' => __( 'Your confirmation input was incorrect.', 'wp-delete-user-accounts' ),
+			'general_error_title' => __( 'Error', 'wp-delete-user-accounts' ),
+			'general_error_text' => __( 'Something went wrong.', 'wp-delete-user-accounts' ),
 			'processing_title' => __( 'Processing...', 'wp-delete-user-accounts' ),
 			'processing_text' => __( 'Just a moment while we process your request.', 'wp-delete-user-accounts' ),
 			'input_placeholder' => sprintf( '%s %s', __( 'Confirm by typing', 'wp-delete-user-accounts' ), $confirm_text ),


### PR DESCRIPTION
The wp_logout-function returned html, so the "Success" or "Error"-prompt wouldn't show up
Also added a "General Error"-prompt to ajax-function